### PR TITLE
Fix Meteor spelling in dark-theme comments

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -23,7 +23,7 @@ import "../styles/404.css";
     <div id="stars3" class="fixed inset-0"></div>
   </div>
 
-  <!-- Dark Theme: Twinkling Stars / Metors -->
+  <!-- Dark Theme: Twinkling Stars / Meteors -->
   <div id="galaxy" class="fixed inset-0">
     <div class="hidden dark:block">
       <TwinklingStars />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,7 +46,7 @@ const stack = [
     <div id='stars3' class='fixed inset-0'></div>
   </div>
 
-  <!-- Dark Theme: Twinkling Stars / Metors -->
+  <!-- Dark Theme: Twinkling Stars / Meteors -->
   <div id="galaxy" class="fixed inset-0">
     <div class="hidden dark:block">
       <TwinklingStars/>

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -21,7 +21,7 @@ import { SITE } from "@consts";
     <div id="stars3" class="fixed inset-0"></div>
   </div>
 
-  <!-- Dark Theme: Twinkling Stars / Metors -->
+  <!-- Dark Theme: Twinkling Stars / Meteors -->
   <div id="galaxy" class="fixed inset-0">
     <div class="hidden dark:block">
       <TwinklingStars />


### PR DESCRIPTION
## Summary
- fix typos in comment headers for dark mode Meteor effect

## Testing
- `npm run lint` *(fails: Script not found "oxlint")*

------
https://chatgpt.com/codex/tasks/task_e_6847ddaa5d44832c8d7cdc3c6240d4d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected minor comment typos related to the spelling of "Meteors" in various pages. No changes to functionality or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->